### PR TITLE
Fix typo in Store endpoint enumeration

### DIFF
--- a/src/main/java/my/petstore/clients/StoreClient.java
+++ b/src/main/java/my/petstore/clients/StoreClient.java
@@ -13,7 +13,7 @@ public class StoreClient implements StoreClientInterface {
     RequestExecutor requestExecutor = new RequestExecutor();
 
     public ResponseEntity<Map<String, Integer>> getPetInventories() {
-        return requestExecutor.executeRequest(StoreEndpoints.INTENTORY.getEndpoint(), new ParameterizedTypeReference<Map<String, Integer>>() {});
+        return requestExecutor.executeRequest(StoreEndpoints.INVENTORY.getEndpoint(), new ParameterizedTypeReference<Map<String, Integer>>() {});
     }
 
     public ResponseEntity<OrderDto> placePetOrder(OrderDto dto) {

--- a/src/main/java/my/petstore/endpoints/StoreEndpoints.java
+++ b/src/main/java/my/petstore/endpoints/StoreEndpoints.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 public enum StoreEndpoints {
-    INTENTORY("store/inventory"),
+    INVENTORY("store/inventory"),
     PLACEORDER("store/order"),
     CHECKORDER("store/order/{param}"),
     DELETEORDER("store/order/{param}");


### PR DESCRIPTION
## Summary
- correct the `StoreEndpoints` enum constant `INTENTORY` to `INVENTORY`
- update `StoreClient` to use the new constant

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68650de77a30832fbb75521243dac78c